### PR TITLE
Fixed inventory issues look at comment for more information on this commit

### DIFF
--- a/scenes/non_quest/player_ui.tscn
+++ b/scenes/non_quest/player_ui.tscn
@@ -43,6 +43,25 @@ position = Vector2(50, 50)
 scale = Vector2(5, 5)
 shape = SubResource("RectangleShape2D_48xfa")
 
+[node name="TextureRect" type="TextureRect" parent="Inventory"]
+layout_mode = 2
+
+[node name="Area2D4" type="Area2D" parent="Inventory"]
+position = Vector2(315, 0)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Inventory/Area2D4"]
+position = Vector2(50, 50)
+scale = Vector2(5, 5)
+shape = SubResource("RectangleShape2D_48xfa")
+
+[node name="Area2D5" type="Area2D" parent="Inventory"]
+position = Vector2(420, 0)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Inventory/Area2D5"]
+position = Vector2(50, 50)
+scale = Vector2(5, 5)
+shape = SubResource("RectangleShape2D_48xfa")
+
 [node name="Quests" type="VBoxContainer" parent="."]
 anchors_preset = 1
 anchor_left = 1.0
@@ -61,10 +80,3 @@ offset_right = 40.0
 offset_bottom = 23.0
 text = "hello"
 script = ExtResource("2_sk4pr")
-
-[connection signal="mouse_entered" from="Inventory/Area2D" to="." method="_on_area_2d_mouse_entered"]
-[connection signal="mouse_exited" from="Inventory/Area2D" to="." method="_on_area_2d_mouse_exited"]
-[connection signal="mouse_entered" from="Inventory/Area2D2" to="." method="_on_area_2d_2_mouse_entered"]
-[connection signal="mouse_exited" from="Inventory/Area2D2" to="." method="_on_area_2d_2_mouse_exited"]
-[connection signal="mouse_entered" from="Inventory/Area2D3" to="." method="_on_area_2d_3_mouse_entered"]
-[connection signal="mouse_exited" from="Inventory/Area2D3" to="." method="_on_area_2d_3_mouse_exited"]

--- a/scripts/emitter.gd
+++ b/scripts/emitter.gd
@@ -10,3 +10,5 @@ signal first_item_pickup
 signal item_picked_up
 
 signal note_picked_up
+
+signal too_many_items

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -13,4 +13,6 @@ var item = {
 }
 var number_items = 0
 var scene_counter = 0
-var note_picked_up = ""
+var notes_picked_up = []
+var can_interact = true
+var did_player_interact = false

--- a/scripts/item_handling.gd
+++ b/scripts/item_handling.gd
@@ -8,15 +8,14 @@ extends Node
 @onready var label_3d_2: Label3D = get_node(label_3d_2_path)
 @export var label_3d_path: NodePath
 @onready var label_3d: Label3D = get_node(label_3d_path)
-
+var message = preload("res://scenes/non_quest/message.tscn")
 func _ready() -> void:
 	area.body_entered.connect(_on_area_3d_body_entered)
 	area.body_exited.connect(_on_area_3d_body_exited)
-
 func _process(delta: float) -> void:
 
 	# making sure the player is near the interactable by checking the label
-	if Input.is_action_just_pressed("interact") and label_3d_2.visible == true:
+	if Input.is_action_just_pressed("interact") and label_3d_2.visible == true and Globals.can_interact:
 		# debug statement
 		# if there is an audio stream
 		if audio:
@@ -27,14 +26,17 @@ func _process(delta: float) -> void:
 		var scene = self.get_scene_file_path()
 		Globals.item[str(self.name)] = scene
 		self.queue_free()
-		if Globals.number_items == 0:
+		if Globals.did_player_interact == false:
 			Emitter.emit_signal("first_item_pickup")
+			Globals.did_player_interact = true
+		if Globals.number_items >= 2:
+			Emitter.emit_signal("too_many_items")
+			Globals.can_interact = false
 		Globals.number_items += 1
 		Emitter.emit_signal("item_picked_up")
 
 # handles label visibility
 func _on_area_3d_body_entered(body: Node3D) -> void:
-	print("HERE")
 	if body.name == "Player":
 		label_3d_2.visible = true
 func _on_area_3d_body_exited(body: Node3D) -> void:

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -19,3 +19,9 @@ func _ready():
 	elif Globals.scene_counter == 2:
 		audio_stream_player.stream = LIMINAL_JAM_LAST_NIGHT_SHIFT
 		audio_stream_player.play()
+	# add another elif or else to direct to another function handling the end scene
+	
+	
+	# reset globals for next rounds
+	Globals.can_interact = true
+	Globals.number_items = 0

--- a/scripts/message.gd
+++ b/scripts/message.gd
@@ -8,4 +8,3 @@ func _ready():
 func _on_button_pressed() -> void:
 	self.queue_free()
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
-	print(Globals.item)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -26,29 +26,21 @@ const BOB_AMP = 0.08
 var sin_bob = 0.0
 
 func _ready():
-	Emitter.first_item_pickup.connect(dislay_message)
+	Emitter.first_item_pickup.connect(display_message.bind(false))
+	Emitter.too_many_items.connect(display_message.bind(true))
 	Emitter.note_picked_up.connect(handle_note_despawn)
-	match Globals.note_picked_up:
-		"lemon_note":
-			lemon_note.visible = false
-			date_note.visible = true
-			work_note.visible = true
-			picnic_note.visible = true
-		"date_note":
-			date_note.visible = false
-			work_note.visible = true
-			picnic_note.visible = true
-			lemon_note.visible = true
-		"picnic_note":
-			date_note.visible = false
-			work_note.visible = true
-			picnic_note.visible = true
-			lemon_note.visible = true
-		"work_note":
-			work_note.visible = false
-			date_note.visible = true
-			picnic_note.visible = true
-			lemon_note.visible = true
+	print(Globals.notes_picked_up)
+	for note in Globals.notes_picked_up:
+		match note:
+			"lemon_note":
+				lemon_note.visible = false
+			"date_note":
+				date_note.visible = false
+			"picnic_note":
+				picnic_note.visible = false
+			"work_note":
+				work_note.visible = false
+
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
@@ -126,30 +118,40 @@ func _headbob(time) -> Vector3:
 	pos.x = cos(time * BOB_FREQ / 2) * BOB_AMP
 	return pos
 	
-func dislay_message():
+func display_message(too_many_items):
 	var message = message.instantiate()
+	var label = message.get_child(0)
+	if too_many_items:
+		label.text = "You have too many items and can no longer pick any more up place the items you have and leave."
+		
+	else:
+		label.text = "Items you pick up will remain in your inventory until you end the shift.
+		Each shift will begin with an empty inventory.
+		Be careful what you pick up... One note and 4 items only!
+		Make sure you handled the items how you wanted before you clock out!"
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	camera_3d.add_child(message)
 
 func handle_note_despawn():
 	var item = Globals.most_recent_node
 	match item:
 		"LemonNote":
-			Globals.note_picked_up = "lemon_note"
+			Globals.notes_picked_up.append("lemon_note")
 			picnic_note.visible = false
 			work_note.visible = false
 			date_note.visible = false
 		"WorkNote":
-			Globals.note_picked_up = "work_note"
+			Globals.notes_picked_up.append("work_note")
 			picnic_note.visible = false
 			date_note.visible = false
 			lemon_note.visible = false
 		"PicnicNote":
-			Globals.note_picked_up = "picknic_note"
+			Globals.notes_picked_up.append("picnic_note")
 			date_note.visible = false
 			work_note.visible = false
 			lemon_note.visible = false
 		"DateNote":
-			Globals.note_picked_up = "date_note"
+			Globals.notes_picked_up.append("date_note") 
 			picnic_note.visible = false
 			work_note.visible = false
 			lemon_note.visible = false

--- a/scripts/player_ui.gd
+++ b/scripts/player_ui.gd
@@ -2,9 +2,10 @@ extends CanvasLayer
 @onready var inventory: HBoxContainer = $Inventory
 @onready var quests: VBoxContainer = $Quests
 
-@onready var area_2d: Array[Area2D] = [$Inventory/Area2D, $Inventory/Area2D2, $Inventory/Area2D3]
+@onready var area_2d: Array[Area2D] = [$Inventory/Area2D, $Inventory/Area2D2, $Inventory/Area2D3, $Inventory/Area2D4, $Inventory/Area2D5]
 @onready var label: Label = $Label
 
+var area_texture_dictionary = {}
 
 var post_it = preload("res://quest_props_tools/LO_post_it_note_tex.png")
 var drill = preload("res://quest_props_tools/LO_drill_drill_tex.png")
@@ -12,17 +13,21 @@ var mirrorstick = preload("res://quest_props_tools/LO_mirrorstick_stick_tex.png"
 var panel_opener = preload("res://quest_props_tools/LO_panel_opener_panel_opener_tex.png")
 var tether_hook = preload("res://quest_props_tools/LO_tether_hook_tex.png")
 var tether_rope = preload("res://quest_props_tools/LO_tether_rope_tex.png")
+var lemon_basket = preload("res://set_dressing_props/LO_cafe_main_shutter_tex.png")
+var mag = preload("res://quest_props_lemonade/LO_mag_mag_tex.png")
 
 func _ready():
+	for area in area_2d:
+		area.mouse_entered.connect(_on_area_2d_mouse_entered.bind(area))
+		area.mouse_exited.connect(_on_area_2d_mouse_exited.bind(area))
 	Emitter.item_picked_up.connect(self.adding_to_inv)
 
 func adding_to_inv():
 	var item_key = Globals.most_recent_node
-	print("Item key is: ", item_key)
 	if item_key in ["WorkNote", "PicnicNote", "DateNote", "LemonNote"]:
 		make_asset(post_it)
 		quest_trigger()
-		Emitter.emit_signal("note_picked_up")
+		Emitter.emit_signal("note_picked_up") 
 	match item_key:
 		"LO_drill2":
 			make_asset(drill)
@@ -34,10 +39,12 @@ func adding_to_inv():
 			make_asset(tether_hook)
 		"tetherropeasset":
 			make_asset(tether_rope)
-
+		"LO_basket_filled_star2":
+			make_asset(lemon_basket)
+		"LO_mag":
+			make_asset(mag)
 func quest_trigger():
 	var item_node = Globals.most_recent_node
-	print(Globals.note_picked_up)
 	match item_node:
 		"DateNote":
 			date_night_quest()
@@ -54,15 +61,9 @@ func make_asset(texture):
 	texture_rect.expand_mode = texture_rect.EXPAND_FIT_WIDTH
 	texture_rect.name = Globals.most_recent_node
 	inventory.add_child(texture_rect)
-	# store the area
+	
 	var area = area_2d[Globals.number_items - 1]
-	# store the collision
-	var collision = area.get_child(0)
-	area.remove_child(collision)
-	# reparent to texture
-	get_parent().remove_child(area)
-	texture_rect.add_child(area)
-	area.add_child(collision)
+	area_texture_dictionary[area] = texture_rect
 
 func date_night_quest():
 	var v_box = VBoxContainer.new()
@@ -110,48 +111,14 @@ func lemon_cake_quest():
 	v_box.add_child(quest_title)
 	v_box.add_child(quest_information)
 
+func _on_area_2d_mouse_entered(area):
+	var texture_rect = area_texture_dictionary.get(area)
+	if texture_rect:
+		handle_label_inv(texture_rect.name)
 
-
-func _on_area_2d_mouse_entered() -> void:
-	# get the name of the texture rectangle to get corresponding text
-	var node_name
-	for child in inventory.get_children():
-		if child is TextureRect:
-			node_name = child.name
-	handle_label_inv(node_name)
-
-	# otherwise it is an actual item
-	
-func _on_area_2d_2_mouse_entered() -> void:
-	# get the name of the texture rectangle to get corresponding text
-	var node_name
-	var count = 0
-	for child in inventory.get_children():
-		if child is TextureRect:
-			count += 1
-		if child is TextureRect and count == 1:
-			node_name = child.name
-	handle_label_inv(node_name)
-
-	# otherwise it is an actual item	
-func _on_area_2d_3_mouse_entered() -> void:
-	# get the name of the texture rectangle to get corresponding text
-	var node_name
-	var count = 0
-	for child in inventory.get_children():
-		if child is TextureRect:
-			count += 1
-		if child is TextureRect and count == 2:
-			node_name = child.name
-	handle_label_inv(node_name)
-	# otherwise it is an actual item
-
-func _on_area_2d_mouse_exited() -> void:
+func _on_area_2d_mouse_exited(area):
 	label.visible = false
-func _on_area_2d_2_mouse_exited() -> void:
-	label.visible = false
-func _on_area_2d_3_mouse_exited() -> void:
-	label.visible = false
+
 
 func handle_label_inv(node_name):
 	match node_name:


### PR DESCRIPTION
- Fixed inventory by adding textures directly instead of re-parenting
- Various bugs with resetting globals for item count, interacting, etc
- Adds a 5 item limit with a message showing up when trying to pickup more disabling the ability to interact until the next round
- Notes despawn correctly (typos fixed)
- Notes from previous rounds are remembered and removed for consecutive rounds